### PR TITLE
Extend list of installed deps.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,6 @@ script:
 
   # Verify Ansible is available in the container.
   - docker exec --tty test-container env TERM=xterm ansible --version
+
+  # Verify Git is available in the container.
+  - docker exec --tty test-container env TERM=xterm git --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN yum makecache fast \
       ansible \
       sudo \
       which \
+      git \
  && yum clean all
 
 # Disable requiretty.

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ RUN yum makecache fast \
       sudo \
       which \
       git \
+      selinux-policy \
+      libselinux-python \
+      policycoreutils-python \
  && yum clean all
 
 # Disable requiretty.


### PR DESCRIPTION
I'm missing git dependency for downloading roles using `ansible-galaxy`.
Handy to have selinux packages installed, so you can use `ansible_selinux.status` fact.