### PR TITLE
Fix formatting for the `ansible` command examples and add bash shell example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This image is built on Docker Hub automatically any time the upstream OS contain
       docker exec --tty [container_id] env TERM=xterm ansible-playbook /path/to/ansible/playbook.yml --syntax-check`
 
       # Enter a shell in the container.
-      docker exec --tty [container_id] env TERM=xterm bash
+      docker exec --tty -i [container_id] env TERM=xterm bash
 
       ```
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,19 @@ This image is built on Docker Hub automatically any time the upstream OS contain
   1. [Install Docker](https://docs.docker.com/engine/installation/).
   2. Pull this image from Docker Hub: `docker pull geerlingguy/docker-centos7-ansible:latest` (or use the image you built earlier, e.g. `centos7-ansible:latest`).
   3. Run a container from the image: `docker run --detach --privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro geerlingguy/docker-centos7-ansible:latest` (to test my Ansible roles, I add in a volume mounted from the current working directory with ``--volume=`pwd`:/etc/ansible/roles/role_under_test:ro``).
-  4. Use Ansible inside the container:
-    a. `docker exec --tty [container_id] env TERM=xterm ansible --version`
-    b. `docker exec --tty [container_id] env TERM=xterm ansible-playbook /path/to/ansible/playbook.yml --syntax-check`
+  4. Use commands such as `ansible` and `ansible-playbook` inside the container:
+  
+      ```
+      # Run `ansible --version`
+      docker exec --tty [container_id] env TERM=xterm ansible --version`
+
+      # Run `ansible-playbook /path/to/ansible/playbook.yml --syntax-check`
+      docker exec --tty [container_id] env TERM=xterm ansible-playbook /path/to/ansible/playbook.yml --syntax-check`
+
+      # Enter a shell in the container.
+      docker exec --tty [container_id] env TERM=xterm bash
+
+      ```
 
 ## Notes
 


### PR DESCRIPTION
Just a little README fix.