### PR TITLE
Updated SystemD version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@ FROM centos:7
 LABEL maintainer="Jeff Geerling"
 ENV container=docker
 
-ENV pip_packages "ansible"
+ENV LANG="en_US.UTF-8"
+ENV LC_ALL="en_US.UTF-8"
+ENV pip_packages "ansible==4.10.0"
 
 # Install systemd -- See https://hub.docker.com/_/centos/
 RUN yum -y update; yum clean all; \
@@ -17,19 +19,21 @@ rm -f /lib/systemd/system/anaconda.target.wants/*;
 
 # Install requirements.
 RUN yum makecache fast \
- && yum -y install deltarpm epel-release initscripts \
+ && yum -y install wget deltarpm epel-release initscripts \
+ && wget --no-check-certificate https://copr.fedorainfracloud.org/coprs/jsynacek/systemd-backports-for-centos-7/repo/epel-7/jsynacek-systemd-backports-for-centos-7-epel-7.repo -O /etc/yum.repos.d/jsynacek-systemd-centos-7.repo \
+ && yum makecache fast \
  && yum -y update \
  && yum -y install \
       sudo \
       which \
-      python-pip \
+      python3-pip \
  && yum clean all
 
 # Upgrade Pip so cryptography package works.
-RUN python -m pip install --upgrade pip==20.3.4
+RUN python3 -m pip install --upgrade pip==21.3.1
 
 # Install Ansible via Pip.
-RUN pip install $pip_packages
+RUN pip3 install $pip_packages
 
 # Disable requiretty.
 RUN sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers


### PR DESCRIPTION
CentOS7 has 219 version that not support `cgroups v2`. So it not working `systemd` with latest containers desktop software like Rancher Desktop, Podman Desktop and Docker Desktop.

Solution is upgrade systemd to latest: https://maciej.lasyk.info/2016/Dec/16/systemd-231-latest-in-centos-7-thx-to-facebook/

So I modified `Dockerfile`

Image build successful and runs.
```shell
❯ podman images
REPOSITORY                 TAG         IMAGE ID      CREATED        SIZE
localhost/centos7-ansible  latest      8b90aa09f595  2 hours ago    994 MB
quay.io/centos/centos      7           8652b9f0cb4c  24 months ago  212 MB
```
Run
```shell
docker-centos7-ansible on  master 
❯ podman exec -it silly_solomon bash
[root@146df88e0ac0 /]# systemctl --version
systemd 234
+PAM +AUDIT +SELINUX +IMA -APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD -IDN2 +IDN default-hierarchy=hybrid
[root@146df88e0ac0 /]# systemctl status
● 146df88e0ac0
    State: running
     Jobs: 0 queued
   Failed: 0 units
    Since: Mon 2022-11-07 16:01:05 UTC; 11min ago
   CGroup: /
           ├─init.scope
           │ ├─  1 /usr/lib/systemd/systemd
           │ ├─121 bash
           │ ├─131 systemctl status
           │ └─132 more
           └─system.slice
             ├─systemd-udevd.service
             │ └─28 /usr/lib/systemd/systemd-udevd
             ├─systemd-journald.service
             │ └─21 /usr/lib/systemd/systemd-journald
             ├─dbus.service
             │ └─78 /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation
             └─systemd-logind.service
               └─77 /usr/lib/systemd/systemd-logind
[root@146df88e0ac0 /]# 
```

Can you merge those changes to you main repo and update image in https://hub.docker.com/r/geerlingguy/docker-centos7-ansible

So it will help me not modify a lot of molecule configuration :) 

Thank you in advance.